### PR TITLE
Fix hardwareserial

### DIFF
--- a/Seatalk.cpp
+++ b/Seatalk.cpp
@@ -15,6 +15,8 @@
 
  *  You should have received a copy of the GNU General Public License
  *  along with FreeBoard.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Updated 20 October 2016 by aayaffe@github (fixed 9 bit read)
  */
 /* Seatalk routines*/
 
@@ -90,7 +92,7 @@ void Seatalk::cancelMOB() {
 	serial->write9(0x00, false);
 	serial->write9(0x01, false);
 }
-void Seatalk::processSeaTalkByte(byte inByte) {
+void Seatalk::processSeaTalkByte(uint16_t inByte) {
 	if (inByte > 256) {
 		//process last datagram....would be nice to do this earlier but how to know its ended?
 		//second byte (4 least significant bits have additional bytes. Length is 3 + additional bytes
@@ -138,15 +140,15 @@ void Seatalk::radarCommand(byte * seatalkStream) {
 	}
 }
 void Seatalk::processSeatalk(byte * seatalkStream) {
-	/* if(DEBUG){
-	 Serial.print("Processing ");
-	 int x =0;
-	 while(seatalkStream[x]!=0x00){
-	 Serial.print(seatalkStream[x],HEX);
-	 x++;
+	 if(DEBUG){
+		 Serial.print("Processing ");
+		 int x =0;
+		 while(seatalkStream[x]!=0x00){
+		 Serial.print(seatalkStream[x],HEX);
+		 x++;
 	 }
 	 Serial.print(": ");
-	 }*/
+	 }
 	//what alarm?
 	switch (seatalkStream[0]) {
 	//MOB, Thomas Knauf says 67 07... but my C70 gives 67 77 ... listen for both
@@ -180,7 +182,7 @@ void Seatalk::processSeatalk(byte * seatalkStream) {
 		windCommand(seatalkStream);
 		break;
 	default:
-		//if(DEBUG)Serial.println("  Command ignored");
+		if(DEBUG)Serial.println("  Command ignored");
 		break;
 	}
 }

--- a/Seatalk.h
+++ b/Seatalk.h
@@ -15,6 +15,8 @@
 
  *  You should have received a copy of the GNU General Public License
  *  along with FreeBoard.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Updated 20 October 2016 by aayaffe@github (fixed 9 bit read)
  */
 /* Seatalk routines*/
 
@@ -74,7 +76,7 @@ public:
 	void windAlarmOff();
 	void radarAlarmOff() ;
 	void cancelMOB() ;
-	void processSeaTalkByte(byte inByte);
+	void processSeaTalkByte(uint16_t inByte);
 private:
 	void windCommand(byte * seatalkStream);
 	void radarCommand(byte * seatalkStream);

--- a/arduinoMods/HardwareSerial.cpp
+++ b/arduinoMods/HardwareSerial.cpp
@@ -20,6 +20,8 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 11 September 2014 by Bouni (Added 9bit serial support)
+  Modified 20 October 2016 by aayaffe@github (merged with arduino core 1.6.14)
 */
 
 #include <stdlib.h>
@@ -82,10 +84,25 @@ void HardwareSerial::_tx_udr_empty_irq(void)
 {
   // If interrupts are enabled, there must be more data in the output
   // buffer. Send the next byte
-  unsigned char c = _tx_buffer[_tx_buffer_tail];
-  _tx_buffer_tail = (_tx_buffer_tail + 1) % SERIAL_TX_BUFFER_SIZE;
+  
+  if(bit_is_set(*_ucsrb, UCSZ02)) {
+    // If Uart is configured for 9 bit mode
+    unsigned char mb = _tx_buffer[_tx_buffer_tail];
+    unsigned char c = _tx_buffer[_tx_buffer_tail + 1];
+    _tx_buffer_tail = (_tx_buffer_tail + 2) % SERIAL_TX_BUFFER_SIZE;
+    if(mb & 0x01) {
+      sbi(*_ucsrb, TXB80);
+    } else {
+      cbi(*_ucsrb, TXB80);
+    }
+    *_udr = c;
+  } else {
+    // UART is configured for 5 to 8 bit modes 
+    unsigned char c = _tx_buffer[_tx_buffer_tail];
+    _tx_buffer_tail = (_tx_buffer_tail + 1) % SERIAL_TX_BUFFER_SIZE;
 
-  *_udr = c;
+    *_udr = c;
+  }
 
   // clear the TXC bit -- "can be cleared by writing a one to its bit
   // location". This makes sure flush() won't return until the bytes
@@ -100,7 +117,7 @@ void HardwareSerial::_tx_udr_empty_irq(void)
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void HardwareSerial::begin(unsigned long baud, byte config)
+void HardwareSerial::begin(unsigned long baud, uint16_t config)
 {
   // Try u2x mode first
   uint16_t baud_setting = (F_CPU / 4 / baud - 1) / 2;
@@ -127,8 +144,12 @@ void HardwareSerial::begin(unsigned long baud, byte config)
 #if defined(__AVR_ATmega8__)
   config |= 0x80; // select UCSRC register (shared with UBRRH)
 #endif
-  *_ucsrc = config;
-  
+
+  if(config & 0x100) {
+    sbi(*_ucsrb, UCSZ02);
+  }
+  *_ucsrc = (uint8_t) config;
+
   sbi(*_ucsrb, RXEN0);
   sbi(*_ucsrb, TXEN0);
   sbi(*_ucsrb, RXCIE0);
@@ -138,8 +159,7 @@ void HardwareSerial::begin(unsigned long baud, byte config)
 void HardwareSerial::end()
 {
   // wait for transmission of outgoing data
-  while (_tx_buffer_head != _tx_buffer_tail)
-    ;
+  flush();
 
   cbi(*_ucsrb, RXEN0);
   cbi(*_ucsrb, TXEN0);
@@ -152,7 +172,15 @@ void HardwareSerial::end()
 
 int HardwareSerial::available(void)
 {
-  return (int)(SERIAL_RX_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail) % SERIAL_RX_BUFFER_SIZE;
+  unsigned int a = (unsigned int) (SERIAL_RX_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail) % SERIAL_RX_BUFFER_SIZE;
+  if(bit_is_set(*_ucsrb, UCSZ02)) {
+    // If Uart is in 9 bit mode return only the half, because we use two bytes per 9 bit "byte".
+    return a / 2;
+  }
+  else {
+    // For 5 - 8 bit modes simply return the number
+    return a;
+  }
 }
 
 int HardwareSerial::peek(void)
@@ -160,7 +188,12 @@ int HardwareSerial::peek(void)
   if (_rx_buffer_head == _rx_buffer_tail) {
     return -1;
   } else {
-    return _rx_buffer[_rx_buffer_tail];
+    if(bit_is_set(*_ucsrb, UCSZ02)) {
+      // If Uart is in 9 bit mode read two bytes and merge them
+      return (_rx_buffer[_rx_buffer_tail] << 8) | _rx_buffer[_rx_buffer_tail + 1 % SERIAL_RX_BUFFER_SIZE];
+    } else {
+      return _rx_buffer[_rx_buffer_tail];
+    }
   }
 }
 
@@ -170,10 +203,33 @@ int HardwareSerial::read(void)
   if (_rx_buffer_head == _rx_buffer_tail) {
     return -1;
   } else {
-    unsigned char c = _rx_buffer[_rx_buffer_tail];
-    _rx_buffer_tail = (rx_buffer_index_t)(_rx_buffer_tail + 1) % SERIAL_RX_BUFFER_SIZE;
-    return c;
+    if(bit_is_set(*_ucsrb, UCSZ02)) {
+      // If Uart is in 9 bit mode read two bytes and merge them
+      unsigned char mb = _rx_buffer[_rx_buffer_tail];
+      unsigned char c = _rx_buffer[_rx_buffer_tail + 1];
+      _rx_buffer_tail = (rx_buffer_index_t)(_rx_buffer_tail + 2) % SERIAL_RX_BUFFER_SIZE;
+      return ((mb << 8) | c);
+    } else {
+      unsigned char c = _rx_buffer[_rx_buffer_tail];
+      _rx_buffer_tail = (rx_buffer_index_t)(_rx_buffer_tail + 1) % SERIAL_RX_BUFFER_SIZE;
+      return c;
+    }
   }
+}
+
+int HardwareSerial::availableForWrite(void)
+{
+#if (SERIAL_TX_BUFFER_SIZE>256)
+  uint8_t oldSREG = SREG;
+  cli();
+#endif
+  tx_buffer_index_t head = _tx_buffer_head;
+  tx_buffer_index_t tail = _tx_buffer_tail;
+#if (SERIAL_TX_BUFFER_SIZE>256)
+  SREG = oldSREG;
+#endif
+  if (head >= tail) return SERIAL_TX_BUFFER_SIZE - 1 - head + tail;
+  return tail - head - 1;
 }
 
 void HardwareSerial::flush()
@@ -196,19 +252,33 @@ void HardwareSerial::flush()
   // the hardware finished tranmission (TXC is set).
 }
 
-size_t HardwareSerial::write(uint8_t c)
+size_t HardwareSerial::write(uint16_t c)
 {
   // If the buffer and the data register is empty, just write the byte
   // to the data register and be done. This shortcut helps
   // significantly improve the effective datarate at high (>
   // 500kbit/s) bitrates, where interrupt overhead becomes a slowdown.
   if (_tx_buffer_head == _tx_buffer_tail && bit_is_set(*_ucsra, UDRE0)) {
-    *_udr = c;
+    if(bit_is_set(*_ucsrb, UCSZ02)) {
+      // in 9 bit mode set TXB8 bit if necessary
+      if(c & 0x100) {
+        sbi(*_ucsrb, TXB80);
+      } else {
+        cbi(*_ucsrb, TXB80);
+      }    
+    }
+    *_udr = (uint8_t) c;
     sbi(*_ucsra, TXC0);
     return 1;
   }
-  tx_buffer_index_t i = (_tx_buffer_head + 1) % SERIAL_TX_BUFFER_SIZE;
-	
+  
+  tx_buffer_index_t i;
+
+  if(bit_is_set(*_ucsrb, UCSZ02)) {
+    i = ((_tx_buffer_head + 2) % SERIAL_TX_BUFFER_SIZE);
+  } else {
+    i = ((_tx_buffer_head + 1) % SERIAL_TX_BUFFER_SIZE);
+  }
   // If the output buffer is full, there's nothing for it other than to 
   // wait for the interrupt handler to empty it a bit
   while (i == _tx_buffer_tail) {
@@ -224,7 +294,13 @@ size_t HardwareSerial::write(uint8_t c)
     }
   }
 
-  _tx_buffer[_tx_buffer_head] = c;
+
+  if(bit_is_set(*_ucsrb, UCSZ02)) {
+    _tx_buffer[_tx_buffer_head] = (uint8_t) (c >> 8) & 0x01;
+    _tx_buffer[_tx_buffer_head + 1] = (uint8_t) c;
+  } else {
+    _tx_buffer[_tx_buffer_head] = (uint8_t) c;
+  }
   _tx_buffer_head = i;
 	
   sbi(*_ucsrb, UDRIE0);
@@ -232,47 +308,11 @@ size_t HardwareSerial::write(uint8_t c)
   
   return 1;
 }
-
-
-//9 bit seatalk protocol
-size_t HardwareSerial::write9(uint8_t c, bool p)
+//Necessary only to maintain compatibility to FreeBoardPLC
+size_t HardwareSerial::write9(uint8_t n, bool c)
 {
-	tx_buffer_index_t i = (_tx_buffer_head + 1) % SERIAL_TX_BUFFER_SIZE;
-
-	// If the output buffer is full, there's nothing for it other than to
-	  // wait for the interrupt handler to empty it a bit
-	  while (i == _tx_buffer_tail) {
-	    if (bit_is_clear(SREG, SREG_I)) {
-	      // Interrupts are disabled, so we'll have to poll the data
-	      // register empty flag ourselves. If it is set, pretend an
-	      // interrupt has happened and call the handler to free up
-	      // space for us.
-	      if(bit_is_set(*_ucsra, UDRE0))
-		_tx_udr_empty_irq();
-	    } else {
-	      // nop, the interrupt handler will free up space for us
-	    }
-	  }
-
-	  _tx_buffer[_tx_buffer_head] = c;
-	    _tx_buffer_head = i;
-
-
-  //set TXB8 (bit 0) with 1 or 0
-    if(p ){
-      *_ucsrb=*_ucsrb | B00000001;
-    }else{
-      *_ucsrb=*_ucsrb & B11111110;
-    }
-
-    sbi(*_ucsrb, UDRIE0);
-     _written = true;
-  //sbi(*_ucsrb, _udrie);
-  // clear the TXC bit -- "can be cleared by writing a one to its bit location"
-  //transmitting = true;
-  //sbi(*_ucsra, TXC0);
-
-  return 1;
+	return write((c<<8) | n);
 }
+
 
 #endif // whole file

--- a/arduinoMods/HardwareSerial.h
+++ b/arduinoMods/HardwareSerial.h
@@ -19,6 +19,9 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 11 September 2014 by Bouni (Added 9bit serial support)
+  Modified 20 October 2016 by aayaffe@github (merged with arduino core 1.6.14)
+  
 */
 
 #ifndef HardwareSerial_h
@@ -32,12 +35,24 @@
 // using a ring buffer (I think), in which head is the index of the location
 // to which to write the next incoming character and tail is the index of the
 // location from which to read.
-#if !(defined(SERIAL_TX_BUFFER_SIZE) && defined(SERIAL_RX_BUFFER_SIZE))
-#if (RAMEND < 1000)
+// NOTE: a "power of 2" buffer size is reccomended to dramatically
+//       optimize all the modulo operations for ring buffers.
+// WARNING: When buffer sizes are increased to > 256, the buffer index
+// variables are automatically increased in size, but the extra
+// atomicity guards needed for that are not implemented. This will
+// often work, but occasionally a race condition can occur that makes
+// Serial behave erratically. See https://github.com/arduino/Arduino/issues/2405
+#if !defined(SERIAL_TX_BUFFER_SIZE)
+#if ((RAMEND - RAMSTART) < 1023)
 #define SERIAL_TX_BUFFER_SIZE 16
-#define SERIAL_RX_BUFFER_SIZE 16
 #else
 #define SERIAL_TX_BUFFER_SIZE 64
+#endif
+#endif
+#if !defined(SERIAL_RX_BUFFER_SIZE)
+#if ((RAMEND - RAMSTART) < 1023)
+#define SERIAL_RX_BUFFER_SIZE 16
+#else
 #define SERIAL_RX_BUFFER_SIZE 64
 #endif
 #endif
@@ -53,33 +68,41 @@ typedef uint8_t rx_buffer_index_t;
 #endif
 
 // Define config for Serial.begin(baud, config);
-#define SERIAL_5N1 0x00
-#define SERIAL_6N1 0x02
-#define SERIAL_7N1 0x04
-#define SERIAL_8N1 0x06
-#define SERIAL_5N2 0x08
-#define SERIAL_6N2 0x0A
-#define SERIAL_7N2 0x0C
-#define SERIAL_8N2 0x0E
-//seatalk
-#define SERIAL_9N1 0x07
+#define SERIAL_5N1 0x000 //0b000000000
+#define SERIAL_6N1 0x002 //0b000000010
+#define SERIAL_7N1 0x004 //0b000000100
+#define SERIAL_8N1 0x006 //0b000000110
+#define SERIAL_9N1 0x106 //0b100000110
 
-#define SERIAL_5E1 0x20
-#define SERIAL_6E1 0x22
-#define SERIAL_7E1 0x24
-#define SERIAL_8E1 0x26
-#define SERIAL_5E2 0x28
-#define SERIAL_6E2 0x2A
-#define SERIAL_7E2 0x2C
-#define SERIAL_8E2 0x2E
-#define SERIAL_5O1 0x30
-#define SERIAL_6O1 0x32
-#define SERIAL_7O1 0x34
-#define SERIAL_8O1 0x36
-#define SERIAL_5O2 0x38
-#define SERIAL_6O2 0x3A
-#define SERIAL_7O2 0x3C
-#define SERIAL_8O2 0x3E
+#define SERIAL_5N2 0x008 //0b000001000
+#define SERIAL_6N2 0x00A //0b000001010
+#define SERIAL_7N2 0x00C //0b000001100
+#define SERIAL_8N2 0x00E //0b000001110
+#define SERIAL_9N2 0x10E //0b100001110
+
+#define SERIAL_5E1 0x020 //0b000100000
+#define SERIAL_6E1 0x022 //0b000100010
+#define SERIAL_7E1 0x024 //0b000100100
+#define SERIAL_8E1 0x026 //0b000100110
+#define SERIAL_9E1 0x126 //0b100100110
+
+#define SERIAL_5E2 0x028 //0b000101000
+#define SERIAL_6E2 0x02A //0b000101010
+#define SERIAL_7E2 0x02C //0b000101100
+#define SERIAL_8E2 0x02E //0b000101110
+#define SERIAL_9E2 0x12E //0b100101110
+
+#define SERIAL_5O1 0x030 //0b000110000
+#define SERIAL_6O1 0x032 //0b000110010
+#define SERIAL_7O1 0x034 //0b000110100
+#define SERIAL_8O1 0x036 //0b000110110
+#define SERIAL_9O1 0x136 //0b100110110
+
+#define SERIAL_5O2 0x038 //0b000111000
+#define SERIAL_6O2 0x03A //0b000111010
+#define SERIAL_7O2 0x03C //0b000111100
+#define SERIAL_8O2 0x03E //0b000111110
+#define SERIAL_9O2 0x13E //0b100111110
 
 class HardwareSerial : public Stream
 {
@@ -110,21 +133,20 @@ class HardwareSerial : public Stream
       volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
       volatile uint8_t *ucsrc, volatile uint8_t *udr);
     void begin(unsigned long baud) { begin(baud, SERIAL_8N1); }
-    void begin(unsigned long, uint8_t);
+    void begin(unsigned long, uint16_t);
     void end();
     virtual int available(void);
     virtual int peek(void);
     virtual int read(void);
+    int availableForWrite(void);
     virtual void flush(void);
-    virtual size_t write(uint8_t);
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
-
-    //support 9 bit seatalk
-    virtual size_t write9(uint8_t c, bool p);
-
+    virtual size_t write(uint16_t);
+    inline size_t write(unsigned long n) { return write((uint16_t)n); }
+    inline size_t write(long n) { return write((uint16_t)n); }
+    inline size_t write(int n) { return write((uint16_t)n); }
+    inline size_t write(int8_t n) { return write((uint16_t)n); }
+    inline size_t write(uint8_t n) { return write((uint16_t)n); }
+    virtual size_t write9(uint8_t n, bool c);
     using Print::write; // pull in write(str) and write(buf, size) from Print
     operator bool() { return true; }
 

--- a/arduinoMods/HardwareSerial_private.h
+++ b/arduinoMods/HardwareSerial_private.h
@@ -1,0 +1,150 @@
+/*
+  HardwareSerial_private.h - Hardware serial library for Wiring
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Modified 23 November 2006 by David A. Mellis
+  Modified 28 September 2010 by Mark Sproul
+  Modified 14 August 2012 by Alarus
+  Modified 11 September 2014 by Bouni (Added 9bit serial support)
+  Modified 20 October 2016 by aayaffe@github (merged with arduino core 1.6.14)
+*/
+
+#include "wiring_private.h"
+
+// this next line disables the entire HardwareSerial.cpp, 
+// this is so I can support Attiny series and any other chip without a uart
+#if defined(HAVE_HWSERIAL0) || defined(HAVE_HWSERIAL1) || defined(HAVE_HWSERIAL2) || defined(HAVE_HWSERIAL3)
+
+// Ensure that the various bit positions we use are available with a 0
+// postfix, so we can always use the values for UART0 for all UARTs. The
+// alternative, passing the various values for each UART to the
+// HardwareSerial constructor also works, but makes the code bigger and
+// slower.
+#if !defined(TXC0)
+#if defined(TXC)
+// Some chips like ATmega8 don't have UPE, only PE. The other bits are
+// named as expected.
+#if !defined(UPE) && defined(PE)
+#define UPE PE
+#endif
+// On ATmega8, the uart and its bits are not numbered, so there is no TXC0 etc.
+#define TXC0 TXC
+#define RXEN0 RXEN
+#define TXEN0 TXEN
+#define RXCIE0 RXCIE
+#define UDRIE0 UDRIE
+#define U2X0 U2X
+#define UPE0 UPE
+#define UDRE0 UDRE
+#define UCSZ02 UCSZ2
+#define TXB80 TXB8
+#define RXB80 RXB8
+#elif defined(TXC1)
+// Some devices have uart1 but no uart0
+#define TXC0 TXC1
+#define RXEN0 RXEN1
+#define TXEN0 TXEN1
+#define RXCIE0 RXCIE1
+#define UDRIE0 UDRIE1
+#define U2X0 U2X1
+#define UPE0 UPE1
+#define UDRE0 UDRE1
+#define UCSZ02 UCSZ12
+#define TXB80 TXB81
+#define RXB80 RXB81
+#else
+#error No UART found in HardwareSerial.cpp
+#endif
+#endif // !defined TXC0
+
+// Check at compiletime that it is really ok to use the bit positions of
+// UART0 for the other UARTs as well, in case these values ever get
+// changed for future hardware.
+#if defined(TXC1) && (TXC1 != TXC0 || RXEN1 != RXEN0 || RXCIE1 != RXCIE0 || \
+		      UDRIE1 != UDRIE0 || U2X1 != U2X0 || UPE1 != UPE0 || \
+		      UDRE1 != UDRE0 || UCSZ12 != UCSZ02 || TXB81 != TXB80 || RXB81 != RXB80)
+#error "Not all bit positions for UART1 are the same as for UART0"
+#endif
+#if defined(TXC2) && (TXC2 != TXC0 || RXEN2 != RXEN0 || RXCIE2 != RXCIE0 || \
+		      UDRIE2 != UDRIE0 || U2X2 != U2X0 || UPE2 != UPE0 || \
+		      UDRE2 != UDRE0 || UCSZ22 != UCSZ02 || TXB82 != TXB80 || RXB82 != RXB80)
+#error "Not all bit positions for UART2 are the same as for UART0"
+#endif
+#if defined(TXC3) && (TXC3 != TXC0 || RXEN3 != RXEN0 || RXCIE3 != RXCIE0 || \
+		      UDRIE3 != UDRIE0 || U3X3 != U3X0 || UPE3 != UPE0 || \
+		      UDRE3 != UDRE0 || UCSZ32 != UCSZ02 || TXB83 != TXB80 || TXB83 != TXB80)
+#error "Not all bit positions for UART3 are the same as for UART0"
+#endif
+
+// Constructors ////////////////////////////////////////////////////////////////
+
+HardwareSerial::HardwareSerial(
+  volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
+  volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
+  volatile uint8_t *ucsrc, volatile uint8_t *udr) :
+    _ubrrh(ubrrh), _ubrrl(ubrrl),
+    _ucsra(ucsra), _ucsrb(ucsrb), _ucsrc(ucsrc),
+    _udr(udr),
+    _rx_buffer_head(0), _rx_buffer_tail(0),
+    _tx_buffer_head(0), _tx_buffer_tail(0)
+{
+}
+
+// Actual interrupt handlers //////////////////////////////////////////////////////////////
+
+void HardwareSerial::_rx_complete_irq(void)
+{
+  if (bit_is_clear(*_ucsra, UPE0)) {
+    // No Parity error, read byte and store it in the buffer if there is
+    // room
+    rx_buffer_index_t i;
+    unsigned char mb;
+    unsigned char c;
+
+    if(bit_is_set(*_ucsrb, UCSZ02)) {
+      // If Uart is configured for 9 bit mode
+      i = (unsigned int)(_rx_buffer_head + 2) % SERIAL_RX_BUFFER_SIZE;
+      mb = (*_ucsrb >> RXB80) & 0x01; 
+      c = *_udr;
+    } else {
+      // UART is configured for 5 to 8 bit modes
+      i = (unsigned int)(_rx_buffer_head + 1) % SERIAL_RX_BUFFER_SIZE;
+      c = *_udr;
+    } 
+
+    // if we should be storing the received character into the location
+    // just before the tail (meaning that the head would advance to the
+    // current location of the tail), we're about to overflow the buffer
+    // and so we don't write the character or advance the head.
+    if (i != _rx_buffer_tail) {
+      if(bit_is_set(*_ucsrb, UCSZ02)) {
+        // If Uart is configured for 9 bit mode
+        _rx_buffer[_rx_buffer_head] = mb;
+        _rx_buffer[_rx_buffer_head + 1] = c;
+      } else {
+        // UART is configured for 5 to 8 bit modes
+        _rx_buffer[_rx_buffer_head] = c;
+      }
+      _rx_buffer_head = i;
+    }
+  } else {
+    // Parity error, read byte but discard it
+    *_udr;
+  };
+}
+
+#endif // whole file

--- a/arduinoMods/README.txt
+++ b/arduinoMods/README.txt
@@ -2,4 +2,4 @@ These two files are modified to allow 9 bit serial from the Mega.
 You need to copy them over the files in the arduino IDE distribution, which shows up in the arduino folder in this project.
 eg copy these files over the ones in {workspace}/arduino/core/
 
-These files are for Arduino IDE 1.5.7, if you have a different version then you should merge the code rather than copy.
+These files are for Arduino IDE 1.6.14, if you have a different version then you should merge the code rather than copy.


### PR DESCRIPTION
Fixed HardwareSerial by merging Bouni's solution. Mainly to address an issue with SeaTalk reading of 9 bit command (It was not reading the extra bit and thus not identifying a SeaTalk command).
Updated SeaTalk class to be able to read a 9 bit command (changed variable type).
Tested in an Arduino mega 1280.
